### PR TITLE
Untitled

### DIFF
--- a/detect/features.js
+++ b/detect/features.js
@@ -25,4 +25,8 @@
         return !!(has(canvas) && typeof doc.createElement( canvas ).getContext('2d').fillText == 'function');
     });
     
+    addtest("native-json", function(){
+		return !!(JSON.toString() == "[object JSON]" && JSON.parse && JSON.stringify);
+	});
+    
 })(has);


### PR DESCRIPTION
Seems to be working correctly in FF, Chrome and Opera where JSON is native. Could do detection with try-catch, wouldn't really detect if it's native though, and would also be a bit costly. I'm aware toString can be overridden, but that's really a minor thing considering that it'll differ from json2.js and native, which is the two usually used (except for simple new Function(...){...} and eval(), which would be wrapped in a function anyway, returning [object Object] or [object Function]).
