### PR TITLE
Bug fix and tiny perf tweak for array.js

### DIFF
--- a/detect/array.js
+++ b/detect/array.js
@@ -1,57 +1,58 @@
 (function(has, addtest, cssprop){
-    
-    var STR = "string",
+
+    var EMPTY_ARRAY = [],
+        STR = "string",
         FN = "function"
     ;
-    
+
     // Array tests
     addtest("array-every", function(){
-        return typeof [].every == FN;
+        return typeof EMPTY_ARRAY.every == FN;
     });
-    
+
     addtest("array-filter", function(){
-        return typeof [].filter == FN;
+        return typeof EMPTY_ARRAY.filter == FN;
     });
-    
+
     addtest("array-foreach", function(){
-        return typeof [].forEach == FN;
+        return typeof EMPTY_ARRAY.forEach == FN;
     });
-    
+
     addtest("array-indexof", function(){
-        return typeof [].indexOf == FN;
+        return typeof EMPTY_ARRAY.indexOf == FN;
     });
-    
+
     addtest("array-isarray", function(){
-        return typeof Array.isArray == FN && Array.isArray([]);
+        return typeof Array.isArray == FN && Array.isArray(EMPTY_ARRAY);
     });
-    
+
     addtest("array-lastindexof", function(){
-        return typeof [].lastIndexOf == FN;
+        return typeof EMPTY_ARRAY.lastIndexOf == FN;
     });
-    
+
     addtest("array-map", function(){
-        return typeof [].map == FN;
+        return typeof EMPTY_ARRAY.map == FN;
     });
-    
+
     addtest("array-reduce", function(){
-        return typeof [].reduce == FN;
+        return typeof EMPTY_ARRAY.reduce == FN;
     });
-    
+
     addtest("array-reduceright", function(){
-        return typeof [].reduce == FN;
+        return typeof EMPTY_ARRAY.reduce == FN;
     });
-    
+
     addtest("array-some", function(){
-        return typeof [].some == FN;
+        return typeof EMPTY_ARRAY.some == FN;
     });
-    
+
     addtest("array-es5", function(){
         return has("array-every") && has("array-filter") && has("array-foreach") &&
             has("array-indexof") && has("array-isarray") && has("array-lastindexof") &&
             has("array-map") && has("array-reduce") && has("array-reduceright") &&
             has("array-some");
     });
-    
+
     addtest('array-slice-nodelist', function(g, d, el){
         var supported = true, de = d.documentElement, id = de.id;
         // Opera 9.25 bug


### PR DESCRIPTION
Fixed array-some testing for map instead of some and added an EMPTY_ARRAY closure var so each test doesn't need to create a new empty array (perf test at http://jsperf.com/feature-detection-on-empty-array-vs-array-prototype).

(emailed a signed Dojo CLA earlier today, btw)
