### PR TITLE
Form test tweaks

### DIFF
--- a/detect/form.js
+++ b/detect/form.js
@@ -132,13 +132,11 @@
     });
 
     addtest("input-type-url", function(){
-        // real url and email support comes with prebaked validation.
-        return has("input-checkvalidity") && supportsModernInputProp("url");
+        return supportsModernInputProp("url");
     });
 
     addtest("input-type-email", function(){
-        // real url and email support comes with prebaked validation.
-        return has("input-checkvalidity") && supportsModernInputProp("email");
+        return supportsModernInputProp("email");
     });
 
     addtest("input-type-datetime", function(){


### PR DESCRIPTION
2 small tweaks here:
1) Typo in the `input-type-url` test, it's testing `supportsModernInputProp("email")` rather than `url`

2) I think the checkValidity test in `input-type-url` and `input-type-email` doesn't make sense. The nature of the smiley test (which I invented over here: http://miketaylr.com/scripts/formsui.js --which might mean the code isn't clean CLA-wise. Maybe changing a frowny to a smiley makes it OK, though :P) relies on the fact that constraintValidation exists and the input value is sanitized. If you want to argue that it does make sense, you at least have to add it for every new input type, barring `type=tel` and `type=search` (where stripping linebreaks is the only requirement).
