### PR TITLE
Fix for false negatives in ogg and wav tests in Opera

### DIFF
--- a/detect/audio.js
+++ b/detect/audio.js
@@ -15,6 +15,9 @@
 
     // TODO: evaluate if these tests fit within the has.js scope because they don't
     // provide a definate yes or no answer
+    //
+    // NOTE: Opera returns a false-negative in this test if there are single spaces
+    // around the codes value, e.g. codes='vorbis'
     addtest("audio-ogg", function(){
         return has("audio") && !!CAN_PLAY_GUESSES[audio.canPlayType("audio/ogg; codecs=vorbis")];
     });


### PR DESCRIPTION
For whatever reason, `audio.canPlayType("audio/ogg; 'codecs=vorbis'")` causes Opera to report that it doesn't support .oga--same for the .wav test. Simply removing the single quotes fixes the issue. Firefoxen and Safari/Chrome don't care either way.
