### PR TITLE
Dynamic Base Tag Patch

### DIFF
--- a/detect/dom.js
+++ b/detect/dom.js
@@ -134,18 +134,20 @@
           fake = false,
           supported = null;
 
-       if(head){
+       if(head && "location" in g){
             base = d.getElementsByTagName("base")[0] || (function(){
                 fake = true;
                 return head.insertBefore(d.createElement("base"), head.firstChild);
             })();
 
             backup = base.href;
-            base.href = (("location" in g) ? location.protocol : "http:") + "//x";
+            base.href = location.protocol + "//x";
             q.cite = "y";
             supported = q.cite.indexOf("x/y") > -1;
 
             if(fake){
+            	//reset to pathname before removal, otherwise href persists in Opera
+            	base.href = location.pathname;
                 head.removeChild(base);
             } else {
                 base.href = backup;


### PR DESCRIPTION
Before removing the base element from the head, you'll need to set its href back to the path of the current page. Otherwise, Opera retains the fake base href path for all subsequent requests after the element is removed from the DOM. 

To make this change, I also moved the test for ("location" in g) so that it must be true to run this support test at all (along with the head existence check). Otherwise, the href can't be set back to location.pathname and you'll have asset loading problems in Opera.

Cheers,
Scott
