### PR TITLE
extra space causes indeterminate test to fail

### DIFF
--- a/detect/form.js
+++ b/detect/form.js
@@ -76,7 +76,7 @@
     });
 
     addtest("input-attr-indeterminate ", function(){
-        return ("indeterminate " in input);
+        return ("indeterminate" in input);
     });
 
     addtest("input-attr-willvalidate", function(){


### PR DESCRIPTION
was: 

``` javascript
addtest("input-attr-indeterminate ", function(){
  return ("indeterminate " in input);
});
```
