### PR TITLE
getAttributeNode of cloned elements test.

### DIFF
--- a/detect/bugs.js
+++ b/detect/bugs.js
@@ -419,5 +419,12 @@
         return buggy;
     });
 
+	// true on IE6 and IE7
+	addtest("bug-cloned-getattributenode-nodevalue", function(g, d, el){
+		var clone = el.cloneNode(false);
+		clone.setAttribute('class', 'test');
+		return clone.getAttributeNode('class').nodeValue != 'test';
+	});
+
 })(has, has.add, has.cssprop);
 


### PR DESCRIPTION
Add test for getAttributeNode().nodeValue of cloned elements which fails in IE6 & IE7
