### PR TITLE
Module boilerplate that supports AMD and node

### DIFF
--- a/detect/__base.js
+++ b/detect/__base.js
@@ -1,6 +1,16 @@
-(function(has, addtest, cssprop){
+(function(factory){
+    if(typeof exports === 'object'){
+        module.exports = factory(require('has'));
+    }else if(typeof define === 'function' && define.amd){
+        define(['has'], factory);
+    }else{
+        factory(has);
+    }
+}(function(has){
 
-    var STR = "string",
+    var addtest = has.add,
+        cssprop = has.cssprop,
+        STR = "string",
         FN = "function"
     ;
 
@@ -17,4 +27,5 @@
         return true; // Boolean
     });
 
-})(has, has.add, has.cssprop);
+    return has;
+}));

--- a/detect/array.js
+++ b/detect/array.js
@@ -1,6 +1,16 @@
-(function(has, addtest, cssprop){
+(function(factory){
+    if(typeof exports === 'object'){
+        module.exports = factory(require('has'));
+    }else if(typeof define === 'function' && define.amd){
+        define(['has'], factory);
+    }else{
+        factory(has);
+    }
+}(function(has){
 
-    var toString = {}.toString,
+    var addtest = has.add,
+        cssprop = has.cssprop,
+        toString = {}.toString,
         EMPTY_ARRAY = [],
         FUNCTION_CLASS = "[object Function]";
 
@@ -53,4 +63,5 @@
             has("array-some");
     });
 
-})(has, has.add, has.cssprop);
+    return has;
+}));

--- a/has.js
+++ b/has.js
@@ -1,4 +1,4 @@
-has = (function(g){
+(function(g){
 
     // summary: A simple feature detection function/framework.
     //
@@ -144,8 +144,16 @@ has = (function(g){
         document.execCommand("BackgroundImageCache", false, true);
     }catch(e){}
 
-    return has;
 
-})(this);
+    if(typeof module === 'object' && module.exports){
+        // For Node
+        module.exports = has;
+    }else if(typeof define === 'function' && define.amd){
+        // AMD. Register as an anonymous module.
+        define(function(){ return has; });
+    }else{
+        // Browser globals
+        g.has = has;
+    }
 
-
+}(this));


### PR DESCRIPTION
This is related to issue #61, but a bit different focus. Allow has.js and its tests to be used in AMD, node and with browser globals.

I only did an initial commit that shows has.js, _base.js and the array.js tests using the boilerplate. If this approach looks good, then i'll add more commits that convert the rest of the detect scripts.

I also have an AMD loader plugin in the works that uses this modified has.js and array.js to choose loading one of two modules, depending on the result of the has test: [here is a use of it](https://github.com/jrburke/require-hasm/blob/master/demo/lib/main.js), and [the hasm loader plugin](https://github.com/jrburke/require-hasm/blob/master/hasm.js).

I'm trying to keep the loader plugin separate from this repo since it is not a core has.js concern, and it allows others to make different kinds of AMD loader plugins on top of has.js, and I did not want to add too much change to this repo.

Going to try ccing @kriszyp and @bryanforbes in this message, hopefully they get notified too. Want them to be aware of this alternate approach to #61 and check my work.
