### PR TITLE
Remove hardcoded AMD module name.

### DIFF
--- a/has.js
+++ b/has.js
@@ -149,7 +149,7 @@
     // Expose has()
     // some AMD build optimizers, like r.js, check for specific condition patterns like the following:
     if(typeof define == "function" && typeof define.amd == "object" && define.amd){
-        define("has", function(){
+        define(function(){
             return has;
         });
     }


### PR DESCRIPTION
Maybe I'm missing something here but hard coding the AMD module name seems problematic to me (and provides no benefits I can see).

According to [the documentation](http://requirejs.org/docs/api.html#modulename):

> You can explicitly name modules yourself, but it makes the modules less portable [...] It is normally best to avoid coding in a name for the module and just let the optimization tool burn in the module names.
