### PR TITLE
Add tests for WebA and Ogg Opus to audio.js

### DIFF
--- a/detect/audio.js
+++ b/detect/audio.js
@@ -34,5 +34,13 @@
         return has("audio") && !!(CAN_PLAY_GUESSES[audio.canPlayType("audio/x-m4a;")] ||
             CAN_PLAY_GUESSES[audio.canPlayType("audio/aac;")]);
     });
+    
+    addtest("audio-opus", function(){
+        return has("audio") && !!CAN_PLAY_GUESSES[audio.canPlayType("audio/ogg; codecs=opus")];
+    })
+    
+    addtest("audio-weba", function(){
+        return has("audio") && !!CAN_PLAY_GUESSES[audio.canPlayType("audio/webm;")];
+    })
 
 })(has, has.add, has.cssprop);


### PR DESCRIPTION
Adds two tests "audio-opus" and "audio-weba" for Ogg Opus and WebM Audio (WebA) support, respectively