### PR TITLE
Added tests for notification API and dialog element

### DIFF
--- a/detect/dialog.js
+++ b/detect/dialog.js
@@ -1,0 +1,30 @@
+(function(has, addtest){
+    
+    var toString = {}.toString,
+        FUNCTION_CLASS = "[object Function]";
+
+    if(!has("dom")){ return; }
+    
+    var dialog = document.createElement("dialog");
+    
+    addtest("dialog", function(){
+        return toString.call(dialog.show) == FUNCTION_CLASS;
+    });
+    
+    addtest("dialog-open", function(){
+        return ("open" in dialog);
+    });
+    
+    addtest("dialog-show", function(){
+        return toString.call(dialog.show) == FUNCTION_CLASS;
+    });
+    
+    addtest("dialog-show-modal", function(){
+        return toString.call(dialog.showModal) == FUNCTION_CLASS;
+    });
+    
+    addtest("dialog-close", function(){
+        return toString.call(dialog.close) == FUNCTION_CLASS;
+    });
+    
+})(has, has.add);

--- a/detect/notification.js
+++ b/detect/notification.js
@@ -1,0 +1,23 @@
+(function(has, addtest){
+    
+    var toString = {}.toString,
+        FUNCTION_CLASS = "[object Function]";
+    
+    if(!has("dom")){ return; }
+    
+    addtest("notification", function(){
+        return toString.call(window.Notification) === FUNCTION_CLASS ||
+                toString.call(window.webkitNotifications) === FUNCTION_CLASS;
+    });
+
+    has.add("notification-checkpermission", function () {
+        return toString.call(window.Notification.permission) === FUNCTION_CLASS ||
+                toString.call(window.webkitNotifications.checkPermission) === FUNCTION_CLASS;
+    });
+
+    has.add("notification-requestpermission", function () {
+        return toString.call(window.Notification.requestPermission) === FUNCTION_CLASS ||
+                toString.call(window.webkitNotifications.requestPermission) === FUNCTION_CLASS;
+    });
+    
+})(has, has.add);


### PR DESCRIPTION
I had written a small program that utilized the [HTML5 Notification API](https://notifications.spec.whatwg.org/) a while back and had made some has.js tests to do feature detection.  I had written them as an AMD module, but rewrote them to be more like the other detect scripts and wanted to contribute them to the project.

I was also playing around with the [dialog element](https://html.spec.whatwg.org/multipage/forms.html#the-dialog-element) the other day and wanted to write a feature detect for that as well since, as of right now, it's only supported in Chrome.  Is this the correct way to contribute tests?

Also, there doesn't seem to be much commenting in the other scripts so I left my comments out.  Is this correct?