### PR TITLE
add flex box detection.

### DIFF
--- a/detect/css.js
+++ b/detect/css.js
@@ -146,7 +146,11 @@
         return cssprop("transform", el);
     });
 
-    // FIXME: modernizr has flexbox, backgroundsize, borderimage, cssanimations, csscolumns, cssgradients,
+    addtest("flex", function(g, d, el){
+        return cssprop("flex", el);
+    });
+
+    // FIXME: modernizr has, backgroundsize, borderimage, cssanimations, csscolumns, cssgradients,
     // cssreflections, csstransforms, csstransforms3d, csstransitions, fontface
 
 })(has, has.add, has.cssprop);


### PR DESCRIPTION
Tested in Safari 6.0.5
![image](https://cloud.githubusercontent.com/assets/1900802/20491030/0d08412e-afde-11e6-9db4-206f79432736.png)
and modern Chrome
![image](https://cloud.githubusercontent.com/assets/1900802/20491054/23405e9a-afde-11e6-8efe-007052b43dc2.png)

